### PR TITLE
Improving posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,6 +3,7 @@ class PostsController < ApplicationController
   before_action :correct_user, only: :destroy
 
   def show
+    @post = Post.find(params[:id])
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :logged_in_user
-  before_action :correct_user, only: :destroy
+  before_action :correct_user, only: [:destroy, :edit, :update]
 
   def show
     @post = Post.find(params[:id])
@@ -28,9 +28,17 @@ class PostsController < ApplicationController
   end
   
   def edit
+    @post = Post.find(params[:id])
   end
 
   def update
+    @post = Post.find(params[:id])
+    if @post.update_attributes(post_params)
+      flash[:success] = "Post updated"
+      redirect_to @post
+    else
+      render 'edit'
+    end
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,6 +6,7 @@ class PostsController < ApplicationController
   end
 
   def new
+    @post = current_user.posts.build
   end
 
   def create
@@ -15,20 +16,20 @@ class PostsController < ApplicationController
       redirect_to root_url
     else
       @feed_items = []
-      render 'static_pages/home'
+      render 'posts/new'
     end
-  end
-
-  def edit
-  end
-
-  def update
   end
 
   def destroy
     @post.destroy
     flash[:success] = "Post deleted"
     redirect_to request.referrer || root_url
+  end
+  
+  def edit
+  end
+
+  def update
   end
 
   private

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,11 +1,11 @@
 <footer class="footer">
   <small>
-    The <a href="https://railstutorial.jp/">Ruby on Rails Tutorial</a>
-    by <a href="http://www.michaelhartl.com/">Michael Hartl</a>
+    Pacifica
   </small>
   <nav>
     <ul>
-      <li><a href="http://news.railstutorial.org/">News</a></li>
+      <li><%= link_to "Home", root_path %></li>
+      <li><%= link_to "Help", help_path %></li>
     </ul>
   </nav>
 </footer>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,9 +3,8 @@
     <%= link_to "Pacifica", root_path, id: "logo" %>
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "Home", root_path %></li>
-        <li><%= link_to "Help", help_path %></li>
         <% if logged_in? %>
+          <li><%= link_to "Share music", new_post_path %></li>
           <li><%= link_to "Users", users_path %></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,11 +1,13 @@
 <li id="post-<%= post.id %>">
   <%= icon_for(post.user) %>
   <span class="user"><%= link_to post.user.name, post.user %></span>
-  <span class="content"><%= post.content %></span>
-  <span class="timestamp">
-    Posted <%= time_ago_in_words(post.created_at) %> ago.
-    <% if current_user?(post.user) %>
-      <%= link_to "delete", post, method: :delete, data: { confirm: "You sure?" } %>
-    <% end %>
-  </span>
+  <a href="<%= post_path(post) %>">
+    <span class="content"><%= post.content %></span>
+    <span class="timestamp">
+      Posted <%= time_ago_in_words(post.created_at) %> ago.
+      <% if current_user?(post.user) %>
+        <%= link_to "delete", post, method: :delete, data: { confirm: "You sure?" } %>
+      <% end %>
+    </span>
+  </a>
 </li>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -6,6 +6,7 @@
     <span class="timestamp">
       Posted <%= time_ago_in_words(post.created_at) %> ago.
       <% if current_user?(post.user) %>
+        <%= link_to "edit", edit_post_path(post) %>
         <%= link_to "delete", post, method: :delete, data: { confirm: "You sure?" } %>
       <% end %>
     </span>

--- a/app/views/posts/_post_form.html.erb
+++ b/app/views/posts/_post_form.html.erb
@@ -1,4 +1,3 @@
-<h1><%= yield(:form_name) %></h1>
 <%= form_for(@post, url: yield(:url)) do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="field">

--- a/app/views/posts/_post_form.html.erb
+++ b/app/views/posts/_post_form.html.erb
@@ -1,0 +1,8 @@
+<h1><%= yield(:form_name) %></h1>
+<%= form_for(@post, url: yield(:url)) do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="field">
+    <%= f.text_area :content, placeholder: yield(:placeholder) %>
+  </div>
+  <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+<% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,9 +1,9 @@
 <% provide(:title, "Edit post") %>
-<% provide(:form_name, "Edit post") %>
 <% provide(:url, post_path) %>
 <% provide(:button_text, "Save") %>
 <div class="row">
   <div class="post_form">
+    <h1>Edit post</h1>
     <%= render 'post_form' %>
   </div>
 </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,9 @@
+<% provide(:title, "Edit post") %>
+<% provide(:form_name, "Edit post") %>
+<% provide(:url, post_path) %>
+<% provide(:button_text, "Save") %>
+<div class="row">
+  <div class="post_form">
+    <%= render 'post_form' %>
+  </div>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,10 @@
 <% provide(:title, "New post") %>
+<% provide(:form_name, "New post") %>
+<% provide(:url, posts_path) %>
+<% provide(:placeholder, "Compose new post") %>
+<% provide(:button_text, "Post") %>
 <div class="row">
   <div class="post_form">
-    <%= render 'shared/post_form' %>
+    <%= render 'post_form' %>
   </div>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,6 @@
+<% provide(:title, "New post") %>
+<div class="row">
+  <div class="post_form">
+    <%= render 'shared/post_form' %>
+  </div>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,10 +1,10 @@
 <% provide(:title, "New post") %>
-<% provide(:form_name, "New post") %>
 <% provide(:url, posts_path) %>
 <% provide(:placeholder, "Compose new post") %>
 <% provide(:button_text, "Post") %>
 <div class="row">
   <div class="post_form">
+    <h1>New post</h1>
     <%= render 'post_form' %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,1 @@
+<%= render @post %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,1 +1,5 @@
-<%= render @post %>
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= render @post %>
+  </div>
+</div>

--- a/app/views/shared/_post_form.html.erb
+++ b/app/views/shared/_post_form.html.erb
@@ -1,7 +1,0 @@
-<%= form_for(@post) do |f| %>
-  <%= render 'shared/error_messages', object: f.object %>
-  <div class="field">
-    <%= f.text_area :content, placeholder: "Compose new post" %>
-  </div>
-  <%= f.submit "Post", class: "btn btn-primary" %>
-<% end %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -7,9 +7,6 @@
       <section class="stats">
         <%= render 'shared/stats' %>
       </section>
-      <section class="post_form">
-        <%= render 'shared/post_form' %>
-      </section>
     </aside>
 
     <div class="col-md-8">

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -6,8 +6,14 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     @post = posts(:orange)
   end
 
+  test "should redirect show when not logged in" do
+    get post_path(@post)
+    assert_redirected_to login_url
+  end
+
   test "should redirect new when not logged in" do
     get new_post_path
+    assert_redirected_to login_url
   end
 
   test "should redirect create when not logged in" do

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -4,6 +4,8 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
   def setup
     @post = posts(:orange)
+    @other_users_post = posts(:ants)
+    @user = users(:michael)
   end
 
   test "should redirect show when not logged in" do
@@ -36,6 +38,32 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference 'Post.count' do
       delete post_path(post)
     end
+    assert_redirected_to root_url
+  end
+
+  test "should redirect edit when not logged in" do
+    get edit_post_path(@post)
+    assert_redirected_to login_url
+  end
+
+  test "should redirect edit when logged in as wrong user" do
+    log_in_as(@user)
+    get edit_post_path(@other_users_post)
+    assert flash.empty?
+    assert_redirected_to root_url
+  end
+
+  test "should redirect update when not logged in" do
+    get edit_post_path(@post)
+    patch post_path(@post), params: { post: { content: "foobar" } }
+    assert_not flash.empty?
+    assert_redirected_to login_url
+  end
+
+  test "should redirect update when logged in as wrong user" do
+    log_in_as(@user)
+    patch post_path(@other_users_post), params: { post: { content: "foobar" } }
+    assert flash.empty?
     assert_redirected_to root_url
   end
 end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -13,5 +13,4 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "title", full_title("Help")
   end
-
 end

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -58,6 +58,7 @@ class FollowingTest < ActionDispatch::IntegrationTest
     get root_path
     @user.feed.paginate(page: 1).each do |post|
       assert_match CGI.escapeHTML(post.content), response.body
+      assert_select 'a[href=?]', post_path(post)
     end
   end
 end

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -53,4 +53,11 @@ class FollowingTest < ActionDispatch::IntegrationTest
       delete relationship_path(relationship), xhr: true
     end
   end
+
+  test "Feed on Home page" do
+    get root_path
+    @user.feed.paginate(page: 1).each do |post|
+      assert_match CGI.escapeHTML(post.content), response.body
+    end
+  end
 end

--- a/test/integration/post_interface_test.rb
+++ b/test/integration/post_interface_test.rb
@@ -37,5 +37,6 @@ class PostInterfaceTest < ActionDispatch::IntegrationTest
     # access wrong user profile (and confirm delete links are not there)
     get user_path(users(:archer))
     assert_select 'a', text: "delete", count: 0
+    assert_select 'a', text: "edit", count: 0
   end
 end

--- a/test/integration/post_interface_test.rb
+++ b/test/integration/post_interface_test.rb
@@ -23,11 +23,13 @@ class PostInterfaceTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to root_url
     follow_redirect!
-    assert_match content, response.body
+    assert_match content, response.body # valid post is showed at home feed
+    first_post = @user.posts.paginate(page: 1).first
+    get post_path(first_post)
+    assert_match content, response.body # valid post is showed at posts show
 
     # delete post
     assert_select 'a', text: "delete"
-    first_post = @user.posts.paginate(page: 1).first
     assert_difference 'Post.count', -1 do
       delete post_path(first_post)
     end

--- a/test/integration/post_interface_test.rb
+++ b/test/integration/post_interface_test.rb
@@ -8,8 +8,8 @@ class PostInterfaceTest < ActionDispatch::IntegrationTest
 
   test "post interface" do
     log_in_as(@user)
-    get root_path
-    assert_select 'div.pagination'
+    get new_post_path
+    assert_template 'posts/new'
     # invalid post
     assert_no_difference 'Post.count' do
       post posts_path, params: { post: { content: "" } }

--- a/test/integration/posts_edit_test.rb
+++ b/test/integration/posts_edit_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class PostsEditTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @post = posts(:orange)
+    @user = users(:michael)
+  end
+  
+  test "unsuccessful edit" do
+    log_in_as(@user)
+    get edit_post_path(@post)
+    assert_template 'posts/edit'
+    patch post_path(@post), params: { post: { content: "" } }
+    assert_not @post.errors.nil?
+    assert_template 'posts/edit'
+  end
+
+  test "successful edit with friendly forwarding" do
+    get edit_post_path(@post)
+    log_in_as(@user)
+    assert_redirected_to edit_post_url(@post)
+    content = "foobar"
+    patch post_path(@post), params: { post: { content: content } }
+    assert_not flash.empty?
+    assert_redirected_to @post
+    @post.reload
+    assert_equal content, @post.content
+  end
+end

--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class SiteLayoutTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @user = users(:michael)
+  end
   
   test "layout links" do
     get root_path

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -30,6 +30,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", users_path
     assert_select "a[href=?]", user_path(@user)
     assert_select "a[href=?]", edit_user_path(@user)
+    assert_select "a[href=?]", new_post_path
 
     # log out
     delete logout_path


### PR DESCRIPTION
postsコントローラを改良。
new, show, edit, updateアクションを追加し、ログインフィルタを設定。
edit, updateアクションには、投稿者以外がアクセスできないようにフィルタを設定。
Homeビューにあった投稿フォームを専用のnewビューに移動。
投稿の詳細表示ページを作成(showビュー)。
各投稿から詳細ページへのリンクを設置。
投稿の編集ページを作成(editビュー)。
各投稿から編集ページへのリンクを設置。
上記変更に合わせてテストを適宜編集。

cssスタイルに関してはアルバム共有機能の追加後に整えることにする。

close #1 