### PR TITLE
Comment posts

### DIFF
--- a/app/assets/javascripts/comments.coffee
+++ b/app/assets/javascripts/comments.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the comments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -464,6 +464,11 @@ aside {
       color: $gray;
       display: block;
       margin-left: 60px;
+      .left_timestamp {
+        span {
+          padding-right: 5px;
+        }
+      }
       .right_timestamp {
         float: right;
         margin-right: 15px;
@@ -502,6 +507,14 @@ aside {
     text-align: right;
     .left_timestamp {
       float: left;
+      span {
+        display: inline-block;
+      }
+      .comment_count {
+        span {
+          font-size: 18px;
+        }
+      }
     }
   }
   .post_form {
@@ -522,6 +535,39 @@ aside {
   margin-top: 15px;
   display: block;
   height: 450px;
+}
+
+/* post comments */
+
+.post_comments {
+  @include index_bg;
+  h3 {
+    padding-top: 10px;
+    font-size: 16px;
+    font-weight: normal;
+  }
+  .comment_form {
+    overflow: hidden;
+    margin-bottom: 10px;
+    .btn {
+      float: right;
+      width: 100px;
+    }
+  }
+}
+
+.comments {
+  @include index(50px, 14px);
+}
+
+.comment {
+  p {
+    font-size: 16px;
+  }
+  .timestamp {
+    text-align: right;
+    color: $gray;
+  }
 }
 
 /* Music serch form */

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,26 @@
+class CommentsController < ApplicationController
+  before_action :logged_in_user
+  
+  def create
+    @post = Post.find(params[:comment][:post_id])
+    @comment = Comment.new(comment_params)
+    if @comment.save
+      redirect_to @post
+    else 
+      redirect_to @post
+      # render 'posts/show'
+    end
+  end
+
+  def destroy
+    @comment = Comment.find(params[:id])
+    @comment.destroy
+    redirect_to request.referrer
+  end
+
+  private
+
+    def comment_params
+      params.require(:comment).permit(:user_id, :post_id, :content)
+    end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,9 +6,9 @@ class CommentsController < ApplicationController
     @comment = Comment.new(comment_params)
     if @comment.save
       redirect_to @post
-    else 
+    else
+      flash[:danger] = "Comment should not be empty or too long (up to 140 characters)."
       redirect_to @post
-      # render 'posts/show'
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,6 +5,8 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
     @user = @post.user
+    @comment = Comment.new
+    @comments = @post.comments
   end
 
   def new
@@ -31,6 +33,7 @@ class PostsController < ApplicationController
   
   def edit
     @post = Post.find(params[:id])
+    @comment = Comment.new
   end
 
   def update

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,5 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+  validates :content, presence: true, length: { maximum: 140 }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,7 @@ class Post < ApplicationRecord
   has_one  :music, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_users, through: :likes, source: :user
+  has_many :comments, dependent: :destroy
   accepts_nested_attributes_for :music, allow_destroy: true
   default_scope -> { order(created_at: :desc) }
   validates :user_id, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :followers, through: :passive_relationships, source: :follower
   has_many :likes, dependent: :destroy
   has_many :like_posts, through: :likes, source: :post
+  has_many :comments, dependent: :destroy
 
   mount_uploader :picture, PictureUploader
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,11 +1,15 @@
-<li class="comment-<%= comment.id %> comment">
-  <%= icon_for(comment.user) %>
-  <%= link_to comment.user.name, comment.user, class: "user" %>
-  <%= comment.content %>
-  <div class="timestamp">
-    <% if current_user?(comment.user) %>
-      <%= link_to "delete", comment, method: :delete, data: { confirm: "You sure?" } %>
-    <% end %>
-    Posted <%= time_ago_in_words(comment.created_at) %> ago.
+<li class="comment-<%= comment.id %> comment row">
+  <div class="col-md-1">
+    <%= icon_for(comment.user) %>
+  </div>
+  <div class="col-md-11">
+    <%= link_to comment.user.name, comment.user, class: "user" %>
+    <p><%= safe_join(comment.content.split("\n"), tag(:br)) %></p>
+    <div class="timestamp">
+      <% if current_user?(comment.user) %>
+        <%= link_to "delete", comment, method: :delete, data: { confirm: "You sure?" } %>
+      <% end %>
+      Posted <%= time_ago_in_words(comment.created_at) %> ago.
+    </div>
   </div>
 </li>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,11 @@
+<li class="comment-<%= comment.id %> comment">
+  <%= icon_for(comment.user) %>
+  <%= link_to comment.user.name, comment.user, class: "user" %>
+  <%= comment.content %>
+  <div class="timestamp">
+    <% if current_user?(comment.user) %>
+      <%= link_to "delete", comment, method: :delete, data: { confirm: "You sure?" } %>
+    <% end %>
+    Posted <%= time_ago_in_words(comment.created_at) %> ago.
+  </div>
+</li>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -1,0 +1,9 @@
+<div id="comment_form" class="comment_form">
+  <%= form_for(@comment) do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+    <%= f.hidden_field :post_id, value: @post.id %>
+    <%= f.hidden_field :user_id, value: @current_user.id %>
+    <%= f.text_area :content, class: "form-control" %>
+    <%= f.submit "comment", class: "btn btn-primary" %>
+  <% end %>
+</div>

--- a/app/views/comments/_comment_form.html.erb
+++ b/app/views/comments/_comment_form.html.erb
@@ -3,7 +3,7 @@
     <%= render 'shared/error_messages', object: f.object %>
     <%= f.hidden_field :post_id, value: @post.id %>
     <%= f.hidden_field :user_id, value: @current_user.id %>
-    <%= f.text_area :content, class: "form-control" %>
+    <%= f.text_area :content, class: "form-control", placeholder: "comment to this impression! (up to 140 characters)" %>
     <%= f.submit "comment", class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/posts/_like_form.html.erb
+++ b/app/views/posts/_like_form.html.erb
@@ -1,4 +1,4 @@
-<span id="like_form" class="like_form left_timestamp">
+<span id="like_form" class="like_form">
 <% if current_user.like?(@post) %>
   <%= render 'unlike' %>
 <% else %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -7,8 +7,14 @@
   </a>
   <div class="timestamp">
     <span class="left_timestamp">
-      <i class="far fa-heart"></i>
-      <%= post.like_users.count %>
+      <span class="comment_count">
+        <i class="far fa-comment"></i>
+        <span><%= post.comments.count %></span>
+      </span>
+      <span>
+        <i class="far fa-heart"></i>
+        <%= post.like_users.count %>
+      </span>
     </span>
     <span class="right_timestamp">Posted <%= time_ago_in_words(post.created_at) %> ago.</span>
   </div>

--- a/app/views/posts/_post_detail.html.erb
+++ b/app/views/posts/_post_detail.html.erb
@@ -2,7 +2,8 @@
   <div class="col-md-10">
     <div class="heading">
       <h2><%= @post.music.name %> - <%= @post.music.artist %></h2>
-    </div>        
+    </div>
+
     <% if current_user?(@post.user) && current_page?(edit_post_path(@post)) %>
       <div class="post_form">
         <%= render 'post_form' %>
@@ -30,6 +31,7 @@
         </span>
       </div>
     <% end %>
+    
   </div>
   
   <div>

--- a/app/views/posts/_post_detail.html.erb
+++ b/app/views/posts/_post_detail.html.erb
@@ -17,6 +17,10 @@
       <div class="content"><%= @post.content %></div>      
       <div class="timestamp">
         <span class="left_timestamp">
+          <span class="comment_count">
+            <i class="far fa-lg fa-comment"></i>
+            <span><%= @post.comments.count %></span>
+          </span>
           <%= render 'like_form' %>
         </span>
         

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,9 +10,12 @@
   
   <div class="post-<%= @post.id %> col-md-8">   
     <%= render 'post_detail' %>
-    <div>
+    <div class="post_comments">
+      <h3>Comment (<%= @post.comments.count %>)</h3>
       <%= render 'comments/comment_form' %>
-      <%= render @comments %>
+      <ul class="comments">
+        <%= render @comments %>
+      </ul>
     </div>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,5 +10,9 @@
   
   <div class="post-<%= @post.id %> col-md-8">   
     <%= render 'post_detail' %>
+    <div>
+      <%= render 'comments/comment_form' %>
+      <%= render @comments %>
+    </div>
   </div>
 </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -26,7 +26,6 @@
   <% end %>
   
   <%= f.submit yield(:button_text), class: "btn btn-primary" %>
-
 <% end %>
 
 <script type="text/javascript">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,13 +10,14 @@ Rails.application.routes.draw do
     end
     resources :likes, only: [:index, :create, :destroy]
   end
-
+  
   get    '/login',  to: 'sessions#new'
   post   '/login',  to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
-
+  
   get  '/posts/new', to: 'posts#new'
   post '/posts/new', to: 'posts#create'
   resources :posts
+  resources :comments, only: [:create, :destroy]
   resources :relationships, only: [:create, :destroy]
 end

--- a/db/migrate/20200928112756_create_comments.rb
+++ b/db/migrate/20200928112756_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.string :content
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_091838) do
+ActiveRecord::Schema.define(version: 2020_09_28_112756) do
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "content"
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "post_id", null: false
@@ -65,6 +75,8 @@ ActiveRecord::Schema.define(version: 2020_09_24_091838) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
   add_foreign_key "musics", "posts"

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  
+  test "should redirect create when not logged in" do
+    assert_no_difference 'Comment.count' do
+      post comments_path
+    end
+    assert_redirected_to login_url
+  end
+
+  test "should redirect destroy when not logged in" do
+    assert_no_difference 'Comment.count' do
+      delete comment_path(comments(:one))
+    end
+    assert_redirected_to login_url
+  end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,6 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: "comment"
+  user: michael
+  post: ants

--- a/test/integration/post_comments_test.rb
+++ b/test/integration/post_comments_test.rb
@@ -14,6 +14,7 @@ class PostCommentsTest < ActionDispatch::IntegrationTest
     assert_no_difference 'Comment.count' do
       post comments_path, params: { comment: { user_id: @user.id, post_id: @post.id, content: "" } }
     end
+    assert_not flash.empty?
     # assert_select 'div#error_explanation'
   end
 

--- a/test/integration/post_comments_test.rb
+++ b/test/integration/post_comments_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class PostCommentsTest < ActionDispatch::IntegrationTest
+  
+  def setup
+    @user = users(:michael)
+    @post = posts(:ants)
+    log_in_as(@user)
+  end
+
+  test "invalid comment" do
+    get post_path(@post)
+    assert_template 'posts/show'
+    assert_no_difference 'Comment.count' do
+      post comments_path, params: { comment: { user_id: @user.id, post_id: @post.id, content: "" } }
+    end
+    # assert_select 'div#error_explanation'
+  end
+
+  test "valid comment" do
+    get post_path(@post)
+    assert_template 'posts/show'
+    assert_difference 'Comment.count', 1 do
+      post comments_path, params: { comment: { user_id: @user.id, post_id: @post.id, content: "comment content" } }
+    end
+    assert_redirected_to post_url(@post)
+    follow_redirect!
+    comment = @user.comments.first
+    assert_match comment.user.name, response.body
+    assert_match comment.content,   response.body
+  end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class CommentTest < ActiveSupport::TestCase
+  
+  def setup
+    @user = users(:michael)
+    @post = posts(:ants)
+    @comment = @post.comments.build(user_id: @user.id, content: "comment content")
+  end
+
+  test "should be valid" do
+    assert @comment.valid?
+  end
+
+  test "content should be present" do
+    @comment.content = ""
+    assert_not @comment.valid?
+  end
+
+  test "content should not be too long" do
+    @comment.content = "a" * 141
+    assert_not @comment.valid?
+  end
+end


### PR DESCRIPTION
投稿に対するコメント機能が完成
いいね機能と同様に、フォーム周りで手間取った。
フォームの最適な実装方法をまとめる必要があると感じた。
コメントフォームのエラーメッセージは表示できていない。
commentsコントローラのcreateアクションからposts/showをレンダリングしようとするが、もとの投稿に戻れないことと、URLがデフォルトの/commentになってしまうため。
postsコントローラのshowアクションを呼び出すと、リダイレクトになってしまいエラーメッセージは表示できない。
ルーティングをpost 'posts/:id' to: 'comments#create'にすればいけるか？未検証 


その他...新しい機能を追加するたびに、CSSスタイルがごちゃついてよく分からなくなってくる。
希望のスタイルにするためにビューも弄っているとそちらもカオスに。
どこかのタイミングでリファクタリングをしておきたい。